### PR TITLE
fix: ignore CRD label differences for Kyverno

### DIFF
--- a/values-baremetal-gpu.yaml
+++ b/values-baremetal-gpu.yaml
@@ -223,6 +223,14 @@ clusterGroup:
           limit: 20
         syncOptions:
           - ServerSideApply=true
+          - RespectIgnoreDifferences=true
+      ignoreDifferences:
+        - group: apiextensions.k8s.io
+          kind: CustomResourceDefinition
+          name: policies.kyverno.io
+          jsonPointers:
+            - /metadata/labels
+            - /metadata/annotations
       extraValueFiles:
         - '/overrides/values-kyverno.yaml'
       overrides:

--- a/values-baremetal.yaml
+++ b/values-baremetal.yaml
@@ -196,6 +196,14 @@ clusterGroup:
           limit: 20
         syncOptions:
           - ServerSideApply=true
+          - RespectIgnoreDifferences=true
+      ignoreDifferences:
+        - group: apiextensions.k8s.io
+          kind: CustomResourceDefinition
+          name: policies.kyverno.io
+          jsonPointers:
+            - /metadata/labels
+            - /metadata/annotations
       extraValueFiles:
         - '/overrides/values-kyverno.yaml'
       overrides:

--- a/values-simple.yaml
+++ b/values-simple.yaml
@@ -129,6 +129,14 @@ clusterGroup:
           limit: 20
         syncOptions:
           - ServerSideApply=true
+          - RespectIgnoreDifferences=true
+      ignoreDifferences:
+        - group: apiextensions.k8s.io
+          kind: CustomResourceDefinition
+          name: policies.kyverno.io
+          jsonPointers:
+            - /metadata/labels
+            - /metadata/annotations
       extraValueFiles:
         - '/overrides/values-kyverno.yaml'
 


### PR DESCRIPTION
## Summary

Fixes ArgoCD sync issues on fresh deployments where Kyverno's migration job creates the `policies.kyverno.io` CRD without Helm labels.

## Changes

- Add `ignoreDifferences` configuration to kyverno application in all profiles (simple, baremetal, baremetal-gpu)
- Add `RespectIgnoreDifferences=true` syncOption to ensure other drift is still detected
- Configure ArgoCD to ignore label and annotation differences on `policies.kyverno.io` CRD

## Root Cause

Kyverno's Helm chart includes a migration job that creates the `policies.kyverno.io` CRD before the chart's CRD templates are applied. This migration job doesn't add Helm labels to the CRD, but the chart expects to manage it with labels. This causes ArgoCD to report the application as OutOfSync.

## Solution

Rather than patching the CRD manually on each deployment, configure ArgoCD to ignore the label/annotation differences on this specific CRD while still respecting all other configuration drift.

## Testing

Deploy on a fresh cluster and verify:
- Kyverno application reaches Synced status without manual intervention
- CRD label differences do not cause OutOfSync state
- Other configuration drift is still detected (RespectIgnoreDifferences ensures this)

Part of Wave 1 attestation hardening work.