### PR TITLE
fix: remove extraSecrets mySecret blocking KBS deployment

### DIFF
--- a/overrides/values-trustee.yaml
+++ b/overrides/values-trustee.yaml
@@ -11,5 +11,3 @@ kbs:
       key: "secret/data/hub/kbsres1"
     - name: "passphrase"
       key: "secret/data/hub/passphrase"
-  extraSecrets:
-    - mySecret


### PR DESCRIPTION
## Problem

The `mySecret` entry in `extraSecrets` (added in PR #85) is blocking KBS deployment in production. The trustee-operator controller fails every ~17 minutes with:

```
Error in creating/updating KBS deployment: Secret "mySecret" not found
```

## Impact

**Production blocker** - all confidential workloads failing:
- ❌ No KBS deployment = no attestation service
- ❌ All kata pods fail: `CreateContainerError` with CDH error: `Get resource failed`
- ❌ hello-openshift secure/insecure pods degraded
- ❌ kbs-access secure pod degraded

## Solution

Remove the `extraSecrets: [mySecret]` section from `overrides/values-trustee.yaml`. This was test configuration that should not have been merged.

## Testing

Verified on live Azure cluster running from main:
- Trustee operator logs show repeated mySecret errors
- KBS deployment never starts
- All kata workloads blocked

After this fix merges, cluster sync will deploy KBS and unblock attestation.

Fixes #85