### PR TITLE
feat: enable firmware reference values in bare metal profiles

### DIFF
--- a/values-baremetal-gpu.yaml
+++ b/values-baremetal-gpu.yaml
@@ -117,7 +117,7 @@ clusterGroup:
       namespace: trustee-operator-system
       project: trustee
       chart: trustee
-      chartVersion: 0.5.*
+      chartVersion: 0.6.*
       extraValueFiles:
         - '/overrides/values-trustee.yaml'
       overrides:

--- a/values-baremetal-gpu.yaml
+++ b/values-baremetal-gpu.yaml
@@ -117,7 +117,7 @@ clusterGroup:
       namespace: trustee-operator-system
       project: trustee
       chart: trustee
-      chartVersion: 0.4.*
+      chartVersion: 0.5.*
       extraValueFiles:
         - '/overrides/values-trustee.yaml'
       overrides:
@@ -126,6 +126,8 @@ clusterGroup:
         - name: kbs.tdx.collateralService
           value: "https://pccs-service.intel-dcap.svc.cluster.local:8042/sgx/certification/v4/"
         - name: kbs.gpu.enabled
+          value: "true"
+        - name: kbs.baremetal.enabled
           value: "true"
 
     storage:

--- a/values-baremetal.yaml
+++ b/values-baremetal.yaml
@@ -107,7 +107,7 @@ clusterGroup:
       namespace: trustee-operator-system
       project: trustee
       chart: trustee
-      chartVersion: 0.5.*
+      chartVersion: 0.6.*
       extraValueFiles:
         - '/overrides/values-trustee.yaml'
       overrides:

--- a/values-baremetal.yaml
+++ b/values-baremetal.yaml
@@ -107,7 +107,7 @@ clusterGroup:
       namespace: trustee-operator-system
       project: trustee
       chart: trustee
-      chartVersion: 0.4.*
+      chartVersion: 0.5.*
       extraValueFiles:
         - '/overrides/values-trustee.yaml'
       overrides:
@@ -115,6 +115,8 @@ clusterGroup:
           value: "true"
         - name: kbs.tdx.collateralService
           value: "https://pccs-service.intel-dcap.svc.cluster.local:8042/sgx/certification/v4/"
+        - name: kbs.baremetal.enabled
+          value: "true"
 
     storage:
       name: storage


### PR DESCRIPTION
## Overview

Wire firmware reference value enforcement into bare metal profiles by updating to trustee-chart v0.6.*.

This is **PR 2D** (final) of Wave 2 (firmware hardening) from the bare metal attestation hardening plan.

## Changes

### values-baremetal.yaml
- ✅ Update trustee `chartVersion: 0.5.*` → `0.6.*`
- ✅ Already has `kbs.baremetal.enabled: "true"` override

### values-baremetal-gpu.yaml  
- ✅ Update trustee `chartVersion: 0.5.*` → `0.6.*`
- ✅ Already has `kbs.baremetal.enabled: "true"` override

## Effect

When deploying bare metal profiles, trustee-chart v0.6.0 will now:

1. **Create firmware-refvals-eso ExternalSecret** 
   - Pulls from `secret/data/hub/firmwareReferenceValues` in Vault
   - Syncs to `firmware-reference-values` secret in cluster

2. **Add firmware values to RVPS**
   - Reads firmware-reference-values secret (single JSON blob with 'json' key)
   - Appends mr_td, rtmr_1, rtmr_2, snp_launch_measurement, xfam to RVPS ConfigMap

3. **Enforce firmware measurements**
   - Attestation policy checks firmware against RVPS values
   - Blocks pods with mismatched firmware
   - Enforces debug=false

## Collection Workflow (PR 2A)

```bash
# On bare metal cluster with kata pod running:
make collect-firmware-refvals

# Review collected values
cat ~/.coco-pattern/firmware-reference-values.json

# Uncomment firmwareReferenceValues in ~/values-secret-coco-pattern.yaml
# Then load to Vault:
make load-secrets
```

## Backwards Compatibility

✅ **Fully backwards compatible:**

**If firmware values NOT pushed to Vault:**
- firmware-refvals-eso created but secret empty
- RVPS block skips (no firmware values to append)
- Attestation policy uses fallback rules
- **Behavior identical to v0.4.0** (init_data-only)

**If firmware values pushed to Vault:**
- Firmware verification enforced
- Debug mode blocked
- Stronger security posture

## Testing Plan

After all Wave 2 PRs merge and v0.6.0 releases:

1. Deploy bare metal cluster with `clusterGroupName: baremetal`
2. Collect firmware values: `make collect-firmware-refvals`
3. Load to Vault: `make load-secrets`
4. Verify attestation enforces firmware checks
5. Test backwards compat: deploy without firmware values, verify init_data-only still works

## Dependencies

- **Requires trustee-chart PR #30** (BREAKING CHANGE: single JSON blob format)
- **Requires trustee-chart v0.6.0 release** (semantic-release after #30 merges)
- **Requires coco-pattern PR #89** (firmware collection workflow - optional merge, workflow is documented)

## Related

Part of Wave 2 (firmware hardening) from the bare metal attestation hardening roadmap.

**Wave 2 PR sequence:**
- PR 2A (#89): coco-pattern firmware collection workflow ✅ Updated
- PR 2B+2C: trustee-chart PR #30 (firmware format + ESO + RVPS + attestation policy)
- **PR 2D (this)**: coco-pattern wire to bare metal profiles

After this merges, Wave 2 is complete and ready for E2E testing.