### PR TITLE
fix: handle empty arrays with set -u in pattern.sh

### DIFF
--- a/pattern.sh
+++ b/pattern.sh
@@ -114,12 +114,12 @@ podman run -it --rm --pull=newer \
     -e TOKEN_SECRET \
     -e UUID_FILE \
     -e VALUES_SECRET \
-    "${PKI_HOST_MOUNT_ARGS[@]}" \
+    "${PKI_HOST_MOUNT_ARGS[@]+"${PKI_HOST_MOUNT_ARGS[@]}"}" \
     -v "$(pwd -P)":"$(pwd -P)" \
     -v "${HOME}":"${HOME}" \
     -v "${HOME}":/pattern-home \
     "${PODMAN_ARGS[@]}" \
-    "${EXTRA_ARGS_ARRAY[@]}" \
+    "${EXTRA_ARGS_ARRAY[@]+"${EXTRA_ARGS_ARRAY[@]}"}" \
     -w "$(pwd -P)" \
     "$PATTERN_UTILITY_CONTAINER" \
     "$@"


### PR DESCRIPTION
## Problem

On macOS with podman machine, running `./pattern.sh make install` fails with:
```
./pattern.sh: line 93: PKI_HOST_MOUNT_ARGS[@]: unbound variable
```

This occurs because:
1. macOS uses podman machine (remote podman)
2. `REMOTE_PODMAN` is non-zero, so `PKI_HOST_MOUNT_ARGS` remains an empty array
3. With `set -u` (nounset mode), expanding empty arrays using `"${array[@]}"` triggers an "unbound variable" error in bash

## Solution

Use conditional expansion `"${array[@]+"${array[@]}"}"` which:
- Expands to nothing if the array is empty
- Expands to array contents if it has elements
- Works correctly with `set -u`

Applied to both `PKI_HOST_MOUNT_ARGS` and `EXTRA_ARGS_ARRAY` for consistency.

## Testing

Verified on macOS with podman machine that `./pattern.sh make install` no longer errors on line 117.

## References

This is a standard bash pattern for handling empty arrays with strict mode (`set -u`).