### PR TITLE
chore: remove redundant overrides and set chart defaults

### DIFF
--- a/charts/all/intel-dcap/values.yaml
+++ b/charts/all/intel-dcap/values.yaml
@@ -3,5 +3,5 @@ baremetal:
     nodeSelector: ""  # optional: hostname for PCCS pinning. Empty = schedule anywhere with tolerations.
 
 secretStore:
-  name: ""
-  kind: ""
+  name: vault-backend
+  kind: ClusterSecretStore

--- a/values-azure-spoke.yaml
+++ b/values-azure-spoke.yaml
@@ -24,9 +24,8 @@ clusterGroup:
     sandbox:
       name: sandboxed-containers-operator
       namespace: openshift-sandboxed-containers-operator
-      source: redhat-operators
       channel: stable
-      installPlanApproval: Manual 
+      installPlanApproval: Manual
       csv: sandboxed-containers-operator.v1.12.0
     cert-manager:
       name: openshift-cert-manager-operator
@@ -57,7 +56,7 @@ clusterGroup:
 
     sandbox:
       name: sandbox
-      namespace: openshift-sandboxed-containers-operator #upstream config
+      namespace: openshift-sandboxed-containers-operator
       project: sandbox
       chart: sandboxed-containers
       chartVersion: 0.2.*

--- a/values-azure.yaml
+++ b/values-azure.yaml
@@ -34,14 +34,12 @@ clusterGroup:
     sandbox:
       name: sandboxed-containers-operator
       namespace: openshift-sandboxed-containers-operator
-      source: redhat-operators
       channel: stable
-      installPlanApproval: Manual 
+      installPlanApproval: Manual
       csv: sandboxed-containers-operator.v1.12.0
     trustee:
       name: trustee-operator
       namespace: trustee-operator-system
-      source: redhat-operators
       channel: stable
       installPlanApproval: Manual
       csv: trustee-operator.v1.1.0
@@ -86,7 +84,7 @@ clusterGroup:
       chartVersion: 0.0.*
     trustee:
       name: trustee
-      namespace: trustee-operator-system #upstream config
+      namespace: trustee-operator-system
       project: trustee
       chart: trustee
       chartVersion: 0.8.*
@@ -97,13 +95,14 @@ clusterGroup:
           value: "true"
     sandbox:
       name: sandbox
-      namespace: openshift-sandboxed-containers-operator #upstream config
+      namespace: openshift-sandboxed-containers-operator
       project: sandbox
       chart: sandboxed-containers
       chartVersion: 0.2.*
     sandbox-policies:
       name: sandbox-policies
-      namespace: openshift-sandboxed-containers-operator #upstream config
+      namespace: openshift-sandboxed-containers-operator
+      project: sandbox
       chart: sandboxed-policies
       chartVersion: 0.2.*
       overrides:

--- a/values-baremetal.yaml
+++ b/values-baremetal.yaml
@@ -39,7 +39,6 @@ clusterGroup:
     sandbox:
       name: sandboxed-containers-operator
       namespace: openshift-sandboxed-containers-operator
-      source: redhat-operators
       channel: stable
       installPlanApproval: Manual
       csv: sandboxed-containers-operator.v1.12.0
@@ -48,7 +47,6 @@ clusterGroup:
     trustee:
       name: trustee-operator
       namespace: trustee-operator-system
-      source: redhat-operators
       channel: stable
       installPlanApproval: Manual
       csv: trustee-operator.v1.1.0
@@ -61,14 +59,10 @@ clusterGroup:
     lvm-operator:
       name: lvms-operator
       namespace: openshift-storage
-      source: redhat-operators
-      installPlanApproval: Automatic
     cnv:
       name: kubevirt-hyperconverged
       namespace: openshift-cnv
-      source: redhat-operators
       channel: stable
-      installPlanApproval: Automatic
     nfd:
       name: nfd
       namespace: openshift-nfd
@@ -261,6 +255,7 @@ clusterGroup:
     sandbox-policies:
       name: sandbox-policies
       namespace: openshift-sandboxed-containers-operator
+      project: sandbox
       chart: sandboxed-policies
       chartVersion: 0.2.*
       annotations:

--- a/values-baremetal.yaml
+++ b/values-baremetal.yaml
@@ -221,11 +221,6 @@ clusterGroup:
           name: sgxdeviceplugin-sample
           jsonPointers:
             - /spec
-      overrides:
-        - name: secretStore.name
-          value: vault-backend
-        - name: secretStore.kind
-          value: ClusterSecretStore
 
     nvidia-gpu:
       name: nvidia-gpu

--- a/values-baremetal.yaml
+++ b/values-baremetal.yaml
@@ -204,12 +204,6 @@ clusterGroup:
       chart: sandboxed-containers
       chartVersion: 0.2.*
       overrides:
-        - name: global.secretStore.backend
-          value: vault
-        - name: secretStore.name
-          value: vault-backend
-        - name: secretStore.kind
-          value: ClusterSecretStore
         - name: enablePeerPods
           value: "false"
 

--- a/values-trusted-hub.yaml
+++ b/values-trusted-hub.yaml
@@ -29,7 +29,6 @@ clusterGroup:
     trustee:
       name: trustee-operator
       namespace: trustee-operator-system
-      source: redhat-operators
       channel: stable
       installPlanApproval: Manual
       csv: trustee-operator.v1.1.0
@@ -75,7 +74,7 @@ clusterGroup:
 
     trustee:
       name: trustee
-      namespace: trustee-operator-system #upstream config
+      namespace: trustee-operator-system
       project: trustee
       chart: trustee
       chartVersion: 0.8.*
@@ -86,7 +85,8 @@ clusterGroup:
           value: "true"
     sandbox-policies:
       name: sandbox-policies
-      namespace: openshift-sandboxed-containers-operator #upstream config
+      namespace: openshift-sandboxed-containers-operator
+      project: sandbox
       chart: sandboxed-policies
       chartVersion: 0.2.*
       overrides:


### PR DESCRIPTION
## Summary

- Remove redundant `source: redhat-operators` from 8 subscriptions (upstream default)
- Remove redundant `installPlanApproval: Automatic` from lvm-operator, cnv (global default)
- Remove `#upstream config` comments from namespace fields
- Add missing `project: sandbox` to sandbox-policies app in 3 topology files
- Remove dead `secretStore` overrides from baremetal sandbox app (template never renders on baremetal)
- Set intel-dcap chart `secretStore` defaults to `vault-backend`/`ClusterSecretStore` instead of empty strings, removing need for inline overrides
- Fix trailing whitespace

## Test plan

- [x] Verified on baremetal deployment (node-02) — all 15 ArgoCD apps Synced/Healthy
- [x] All workload routes responding correctly
- [ ] Azure topology: no functional change (overrides kept where needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)