### PR TITLE
Fix coco-pattern/issues/102: "make collect-firmware-refvals" failing with "jq: error (at <stdin>:1): Cannot iterate over null (null)"

### DIFF
--- a/scripts/collect-firmware-refvals.sh
+++ b/scripts/collect-firmware-refvals.sh
@@ -174,8 +174,8 @@ echo "Extracting reference values..."
 # -r ensures the embedded JSON string is output raw (not quoted),
 # which is required for yq v3 (kislyuk/yq) compatibility.
 # yq v4 (mikefarah/yq) outputs raw scalars by default but -r is harmless.
-yq -r '.data["reference-values.json"]' "$TEMP_DIR/rvps-reference-values.yaml" | \
-  jq '[.[] | {(.name): .value}] | add' > "$OUTPUT_FILE"
+yq -r '.data.reference_value' "$TEMP_DIR/rvps-reference-values.yaml" | \
+  jq 'map_values(@base64d | fromjson)' > "$OUTPUT_FILE"
 
 # Save output
 mkdir -p "$(dirname "$OUTPUT_FILE")"


### PR DESCRIPTION
Description:
Resolves the issue where "make collect-firmware-refvals" fails with "jq: error (at <stdin>:1): Cannot iterate over null (null)"

Related Issue:
Fixes #102 