### PR TITLE
fix: check-pck-expiry checks X.509 cert expiry

### DIFF
--- a/scripts/check-pck-expiry.sh
+++ b/scripts/check-pck-expiry.sh
@@ -51,26 +51,58 @@ else
         qe_id="${secret_name%-pck}"
         echo "  PCK secret: ${secret_name} (QE ID: ${qe_id})"
 
-        DATES=$(oc get secret "$secret_name" -n "$NS" -o jsonpath='{.data.certificate}' | \
+        # The PCK cache blob contains URL-encoded PEM X.509 certs + embedded JSON TCB info
+        oc get secret "$secret_name" -n "$NS" -o jsonpath='{.data.certificate}' | \
             base64 -d | python3 -c "
-import sys, re
+import sys, re, subprocess, urllib.parse
 data = sys.stdin.buffer.read()
 text = data.decode('ascii', errors='ignore')
-matches = re.findall(r'\"nextUpdate\":\"([^\"]+)\"', text)
-if matches:
-    for m in matches:
-        print(m)
-else:
-    print('NONE')
-")
 
-        if [ "$DATES" = "NONE" ]; then
-            echo -e "    ${YELLOW}UNKNOWN${NC}  No expiry date found in PCK cache blob"
-        else
-            echo "$DATES" | while read -r next_update; do
-                check_date "    embedded TCB" "$next_update"
-            done
-        fi
+# X.509 certificate expiry
+decoded = urllib.parse.unquote(text)
+certs = re.findall(r'-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----', decoded, re.DOTALL)
+pck_expiries = []
+for cert in certs:
+    r = subprocess.run(['openssl', 'x509', '-noout', '-subject', '-enddate'],
+        input=cert, capture_output=True, text=True)
+    if r.returncode == 0:
+        lines = r.stdout.strip().split('\n')
+        subj = lines[0].replace('subject=', '').strip()
+        end = lines[1].replace('notAfter=', '').strip() if len(lines) > 1 else ''
+        if 'PCK Certificate' in subj:
+            pck_expiries.append(end)
+        elif end:
+            print(f'CERT|{subj}|{end}')
+if pck_expiries:
+    print(f'CERT|PCK Certificate (x{len(pck_expiries)})|{pck_expiries[0]}')
+
+# TCB info nextUpdate
+for m in re.findall(r'\"nextUpdate\":\"([^\"]+)\"', text):
+    print(f'TCB|{m}')
+
+if not certs and not re.search(r'nextUpdate', text):
+    print('NONE')
+" | while IFS='|' read -r rtype val1 val2; do
+            case "$rtype" in
+                NONE)
+                    echo -e "    ${YELLOW}UNKNOWN${NC}  No expiry data found in PCK cache blob"
+                    ;;
+                CERT)
+                    iso=$(python3 -c "
+from datetime import datetime
+try:
+    dt = datetime.strptime('$val2', '%b %d %H:%M:%S %Y %Z')
+except ValueError:
+    dt = datetime.strptime('$val2', '%b  %d %H:%M:%S %Y %Z')
+print(dt.strftime('%Y-%m-%dT%H:%M:%SZ'))
+" 2>/dev/null)
+                    [ -n "$iso" ] && check_date "    cert: $val1" "$iso"
+                    ;;
+                TCB)
+                    check_date "    TCB nextUpdate" "$val1"
+                    ;;
+            esac
+        done
     done
 fi
 


### PR DESCRIPTION
## Summary

Follow-up to #107. The PCK cache blob stored in `intel-dcap-operator-system` contains **URL-encoded PEM X.509 certificates** (PCK certs + Intel SGX CA chain) alongside the embedded JSON TCB info. The version merged in #107 only checked the TCB `nextUpdate` (collateral freshness), not the actual certificate expiry.

This adds extraction and parsing of the X.509 certs so `check-pck-expiry.sh` reports both:
- **X.509 cert `notAfter`** — PCK certs (~7-year validity) and CA chain
- **TCB `nextUpdate`** — collateral freshness (~30 days)

Both are operationally relevant: stale TCB info can cause attestation failures, and expired certs break the trust chain.

## Test plan

- [x] Tested on live cluster — extracts 8 certs (Platform CA, Root CA, 6 PCK certs) plus TCB nextUpdate dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)