### PR TITLE
fix: pin trustee chart to 0.10.* for azure/trusted-hub, bump airgap mirror to 0.10.2

### DIFF
--- a/airgap/imageset-config-4.22.yaml
+++ b/airgap/imageset-config-4.22.yaml
@@ -116,7 +116,7 @@ mirror:
     - name: quay.io/validatedpatterns/acm:0.1.27
     - name: quay.io/validatedpatterns/hashicorp-vault:0.1.8
     - name: quay.io/validatedpatterns/openshift-external-secrets:0.0.4
-    - name: quay.io/validatedpatterns/trustee:0.10.1
+    - name: quay.io/validatedpatterns/trustee:0.10.2
     - name: quay.io/validatedpatterns/sandboxed-containers:0.2.1
     - name: quay.io/validatedpatterns/sandboxed-policies:0.2.0
 

--- a/airgap/imageset-config-4.22.yaml
+++ b/airgap/imageset-config-4.22.yaml
@@ -116,7 +116,7 @@ mirror:
     - name: quay.io/validatedpatterns/acm:0.1.27
     - name: quay.io/validatedpatterns/hashicorp-vault:0.1.8
     - name: quay.io/validatedpatterns/openshift-external-secrets:0.0.4
-    - name: quay.io/validatedpatterns/trustee:0.10.0
+    - name: quay.io/validatedpatterns/trustee:0.10.1
     - name: quay.io/validatedpatterns/sandboxed-containers:0.2.1
     - name: quay.io/validatedpatterns/sandboxed-policies:0.2.0
 

--- a/values-azure.yaml
+++ b/values-azure.yaml
@@ -87,7 +87,7 @@ clusterGroup:
       namespace: trustee-operator-system
       project: trustee
       chart: trustee
-      chartVersion: 0.9.*
+      chartVersion: 0.10.*
       extraValueFiles:
         - '/overrides/values-trustee.yaml'
         - '/overrides/values-trustee-azure.yaml'

--- a/values-trusted-hub.yaml
+++ b/values-trusted-hub.yaml
@@ -77,7 +77,7 @@ clusterGroup:
       namespace: trustee-operator-system
       project: trustee
       chart: trustee
-      chartVersion: 0.9.*
+      chartVersion: 0.10.*
       extraValueFiles:
         - '/overrides/values-trustee.yaml'
       overrides:


### PR DESCRIPTION
fix: pin trustee chart to 0.10.* for azure/trusted-hub, bump airgap mirror to 0.10.1

values-azure.yaml and values-trusted-hub.yaml were still pinned to
chartVersion: 0.9.*, which excludes the 0.10.x line entirely (semver
wildcard is minor-scoped). This was stale from before the trustee-chart
0.10.0 OCI-chart migration (PR #105/#108), which only touched the
baremetal/baremetal-hub values files.

The gap matters now: trustee-chart v0.10.1 (validatedpatterns/trustee-chart#41)
fixes the Azure RVPS pcr-stash reader, which values-azure.yaml directly
layers via overrides/values-trustee-azure.yaml. Azure deployments were
pinned out of ever receiving that fix.

Also bump the airgap oc-mirror imageset pin (quay.io/validatedpatterns/trustee)
from 0.10.0 to 0.10.1 to match, keeping the airgap mirror in sync with the
same 0.10.x line the baremetal values files resolve to.

