### PR TITLE
fix: exclude credential secret from Azure KbsConfig

### DIFF
--- a/overrides/values-trustee-azure.yaml
+++ b/overrides/values-trustee-azure.yaml
@@ -43,3 +43,19 @@ kbs:
     abiMinor: "31"
     singleSocket: "false"
     smtAllowed: "true"
+
+  # trustee-chart's default kbs.extraSecrets (["credential"]) is unconditionally
+  # added to KbsConfig.spec.kbsSecretResources, but the ACM ConfigurationPolicy
+  # that creates that Secret (pull-secret-credential-policy.yaml) is skipped on
+  # Azure -- peer-pod CDH doesn't fetch registry credentials from KBS there
+  # (pull secrets are distributed to workload namespace SAs instead, see
+  # sandboxed-policies-chart/pull-secret-distribution.yaml). Without this
+  # override, KbsConfig lists a Secret ("credential") that never gets created,
+  # and the kbsconfig-controller fails to deploy KBS with:
+  #   Error in creating/updating KBS deployment: Secret "credential" not found
+  #
+  # Fixed upstream in trustee-chart (kbs.yaml now gates extraSecrets the same
+  # way as the policy) -- see validatedpatterns/trustee-chart#42. This
+  # override can be dropped once coco-pattern picks up a trustee chartVersion
+  # that includes that fix (>= 0.10.1, pending release).
+  extraSecrets: []


### PR DESCRIPTION
## Problem

KBS deployment fails on Azure with:

```
2026-08-31T13:07:19Z INFO kbsconfig-controller Error in creating/updating KBS deployment {"kbsconfig": "trustee-operator-system", "err": "Secret \"credential\" not found"}
```

**Root cause:** trustee-chart's `KbsConfig` CR unconditionally lists
`kbs.extraSecrets` (default: `["credential"]`) in
`spec.kbsSecretResources`. The only thing that creates a Secret literally
named `credential` in `trustee-operator-system` is an ACM
`ConfigurationPolicy` (`pull-secret-credential-policy.yaml`) that is
explicitly skipped on Azure — peer-pod CDH doesn't fetch registry
credentials from KBS there; pull secrets are distributed to workload
namespace service accounts instead (see
`sandboxed-policies-chart/pull-secret-distribution.yaml`). Nothing in
coco-pattern's Azure overrides removed `credential` from `kbs.extraSecrets`
to match, so `KbsConfig` kept declaring a dependency the platform never
satisfies.

## Fix

Override `kbs.extraSecrets: []` in `overrides/values-trustee-azure.yaml`.

This is a **workaround at the currently-pinned trustee `chartVersion: 0.10.*`**.
The proper fix — gating the `extraSecrets` range in trustee-chart's
`templates/kbs.yaml` with the same condition used by
`pull-secret-credential-policy.yaml` — is proposed upstream in
[validatedpatterns/trustee-chart#42](https://github.com/validatedpatterns/trustee-chart/pull/42).
Once that's merged and released as `>= 0.10.1`, this override becomes
redundant (both agree `extraSecrets` should be empty on Azure) but harmless,
and can be dropped in a follow-up.

## Verification

Rendered `KbsConfig` via `helm template` against both the currently
published trustee-chart 0.10.0 (unfixed) and the proposed
trustee-chart#42 fix, stacking `overrides/values-trustee.yaml` +
`overrides/values-trustee-azure.yaml` exactly as `values-azure.yaml`'s
`extraValueFiles` does:

- Azure, `secured=true`: `kbsSecretResources` no longer includes
  `"credential"` in either case.
- Bare metal (`clusterPlatform` unset/non-Azure): unaffected — this override
  only applies via `values-trustee-azure.yaml`, loaded for the Azure
  topology only.

## Related

- validatedpatterns/trustee-chart#42 (chart-level fix)