### PR TITLE
fix: exclude credential secret from Azure KbsConfig

### DIFF
--- a/overrides/values-trustee-azure.yaml
+++ b/overrides/values-trustee-azure.yaml
@@ -43,3 +43,22 @@ kbs:
     abiMinor: "31"
     singleSocket: "false"
     smtAllowed: "true"
+
+  # trustee-chart's default kbs.extraSecrets (["credential"]) is unconditionally
+  # added to KbsConfig.spec.kbsSecretResources, but the ACM ConfigurationPolicy
+  # that creates that Secret (pull-secret-credential-policy.yaml) is skipped on
+  # Azure -- peer-pod CDH doesn't fetch registry credentials from KBS there.
+  # Without this override, KbsConfig lists a Secret ("credential") that never
+  # gets created, and the kbsconfig-controller fails to deploy KBS with:
+  #   Error in creating/updating KBS deployment: Secret "credential" not found
+  #
+  # Confirmed on a live Azure cluster that image pulls already work via
+  # sandboxed-policies-chart's pull-secret-distribution mechanism
+  # (per-namespace 'pull-secret' Secret + default ServiceAccount
+  # imagePullSecrets patch) -- the KBS 'credential' resource is genuinely
+  # unnecessary on Azure, not just unused.
+  #
+  # Fixed upstream in trustee-chart -- see validatedpatterns/trustee-chart#42.
+  # This override can be dropped once coco-pattern picks up a trustee
+  # chartVersion that includes that fix (>= 0.10.1, pending release).
+  extraSecrets: []


### PR DESCRIPTION
## Problem

KBS deployment fails on Azure with:

```
2026-08-31T13:07:19Z INFO kbsconfig-controller Error in creating/updating KBS deployment {"kbsconfig": "trustee-operator-system", "err": "Secret \"credential\" not found"}
```

**Root cause:** trustee-chart's `KbsConfig` CR unconditionally lists
`kbs.extraSecrets` (default: `["credential"]`) in
`spec.kbsSecretResources`. The only thing that creates a Secret literally
named `credential` in `trustee-operator-system` is an ACM
`ConfigurationPolicy` (`pull-secret-credential-policy.yaml`) that is
explicitly skipped on Azure — peer-pod CDH doesn't fetch registry
credentials from KBS there.

**Confirmed this is genuinely fine to skip on Azure**, not just
theoretically: on a live Azure cluster, `sandboxed-policies-chart`'s
`pull-secret-distribution` mechanism is already deployed and working —
`pull-secret` Secrets exist in workload namespaces (`hello-openshift`,
`kbs-access`) and the `default` ServiceAccount in those namespaces already
has `imagePullSecrets` patched to use it. Registry auth for Azure peer-pods
does not depend on KBS at all.

## Fix

Override `kbs.extraSecrets: []` in `overrides/values-trustee-azure.yaml`.

This is a **workaround at the currently-pinned trustee `chartVersion: 0.10.*`**.
The proper fix — gating the `extraSecrets` range in trustee-chart's
`templates/kbs.yaml` with the same condition used by
`pull-secret-credential-policy.yaml` — is in
[validatedpatterns/trustee-chart#42](https://github.com/validatedpatterns/trustee-chart/pull/42).
Once that's merged and released as `>= 0.10.1`, this override becomes
redundant (both agree `extraSecrets` should be empty on Azure) but harmless,
and can be dropped in a follow-up.

## Verification

Rendered `KbsConfig` via `helm template` against the currently published
trustee-chart 0.10.0, stacking `overrides/values-trustee.yaml` +
`overrides/values-trustee-azure.yaml` exactly as `values-azure.yaml`'s
`extraValueFiles` does: `kbsSecretResources` no longer includes
`"credential"`. Bare metal is unaffected — this override only applies via
`values-trustee-azure.yaml`, loaded for the Azure topology only.

## Related

- validatedpatterns/trustee-chart#42 (chart-level fix)