### PR TITLE
fix: honor PULL_SECRET env var in firmware refval collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ For air-gapped bare metal environments, see [`airgap/DEPLOY-RUNBOOK.md`](airgap/
 **Common:**
 
 - Tools on your workstation: `podman`, `yq`, `jq`, `skopeo`
-- OpenShift pull secret saved at `~/pull-secret.json` (download from [console.redhat.com](https://console.redhat.com/openshift/downloads))
+- OpenShift pull secret saved at `~/pull-secret.json` (download from [console.redhat.com](https://console.redhat.com/openshift/downloads)), or point elsewhere via the `PULL_SECRET` environment variable
 - Fork the repository — ArgoCD reconciles cluster state against your fork, so changes must be pushed to your remote
 
 ### Secrets and reference value setup
@@ -97,7 +97,7 @@ For air-gapped bare metal environments, see [`airgap/DEPLOY-RUNBOOK.md`](airgap/
 These scripts generate the cryptographic material and attestation reference values needed by Trustee. Run them once before your first deployment.
 
 1. `make gen-secrets` — generates KBS key pairs, sealed-secrets signing keys, and copies `values-secret.yaml.template` to `~/values-secret-coco-pattern.yaml`
-2. Collect attestation reference values (requires `veritas` — `pip install "osc-veritas[snp]==0.1.3rc1"` —, `cosign` >= 2.0 for Azure, `yq`, `jq`, and `~/pull-secret.json`). By default this collects and merges reference values for **both TDX and SNP**:
+2. Collect attestation reference values (requires `veritas` — `pip install "osc-veritas[snp]==0.1.3rc1"` —, `cosign` >= 2.0 for Azure, `yq`, `jq`, and `~/pull-secret.json` or `PULL_SECRET`). By default this collects and merges reference values for **both TDX and SNP**:
    - **Azure:** `make collect-azure-refvals` — pulls PCR measurements from the dm-verity image via veritas. Saves to `~/.coco-pattern/measurements.json`.
    - **Bare metal:** `make collect-firmware-refvals` — computes firmware measurements from OCP release artifacts via veritas. Saves to `~/.coco-pattern/firmware-reference-values.json`. `pcrStash` and `firmwareReferenceValues` are both enabled by default in `~/values-secret-coco-pattern.yaml`, so nothing needs to be uncommented — the collection script automatically writes an empty `{}` placeholder for the platform you're not using.
    - See [docs/firmware-reference-values.md](docs/firmware-reference-values.md) for detailed workflow and options.

--- a/docs/firmware-reference-values.md
+++ b/docs/firmware-reference-values.md
@@ -22,7 +22,7 @@ By default, `collect-firmware-refvals.sh` collects reference values for **both T
 - `veritas` installed on the host: `pip install "osc-veritas[snp]==0.1.3rc1"`
 - `cosign` >= 2.0 — Azure only, used by veritas to verify the Red Hat dm-verity image signature: <https://docs.sigstore.dev/cosign/system_config/installation/>
 - `yq` and `jq` installed
-- OpenShift pull secret at `~/pull-secret.json`
+- OpenShift pull secret at `~/pull-secret.json` (override the location with the `PULL_SECRET` environment variable or `--pull-secret`)
 - For bare metal: OCP version of your cluster (auto-detected if `oc` is logged in)
 - For bare metal TDX: `tdx-measure` (`cargo install --git https://github.com/virtee/tdx-measure tdx-measure-cli`) — collection continues with a warning if absent, but TDX RTMR values will be incomplete
 
@@ -71,7 +71,8 @@ Veritas resolves the kata-containers and edk2-ovmf RPMs from the OCP release pay
 Options:
   --platform <platform>    Platform: baremetal (default) or azure
   -o, --output <path>      Override output path
-  -p, --pull-secret <path> Pull secret file (default: ~/pull-secret.json)
+  -p, --pull-secret <path> Pull secret file (default: ~/pull-secret.json,
+                           override via PULL_SECRET env var)
   -v, --ocp-version <ver>  OCP version (baremetal; default: auto-detect)
   --osc-version <ver>      OSC operator version (azure; default: auto-detect)
   -t, --tee <tdx|snp|both> TEE type (default: both -- collects and merges both)

--- a/rhdp/wrapper.sh
+++ b/rhdp/wrapper.sh
@@ -189,7 +189,7 @@ bash ./scripts/gen-secrets.sh
 echo "---------------------"
 echo "retrieving PCR measurements"
 echo "---------------------"
-bash ./scripts/collect-firmware-refvals.sh --platform azure --tee snp
+bash ./scripts/collect-firmware-refvals.sh --platform azure --tee snp --pull-secret "${PULL_SECRET:-$HOME/pull-secret.json}"
 
 sleep 60
 echo "---------------------"

--- a/scripts/collect-firmware-refvals.sh
+++ b/scripts/collect-firmware-refvals.sh
@@ -28,7 +28,8 @@
 # Options:
 #   --platform <platform>    Platform: baremetal (default) or azure
 #   -o, --output <path>      Override output path
-#   -p, --pull-secret <path> Pull secret file (default: ~/pull-secret.json)
+#   -p, --pull-secret <path> Pull secret file (default: ~/pull-secret.json,
+#                            override via PULL_SECRET env var)
 #   -v, --ocp-version <ver>  OCP version (baremetal; default: auto-detect)
 #   --osc-version <ver>      OSC operator version (azure; default: auto-detect)
 #   -t, --tee <tdx|snp|both> TEE type (default: both -- collects and merges both)
@@ -43,7 +44,7 @@ set -euo pipefail
 # Defaults
 PLATFORM="baremetal"
 OUTPUT_FILE=""
-PULL_SECRET="${HOME}/pull-secret.json"
+PULL_SECRET="${PULL_SECRET:-${HOME}/pull-secret.json}"
 OCP_VERSION=""
 OSC_VERSION=""
 TEE="both"
@@ -82,7 +83,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -h|--help)
-            sed -n '2,39p' "$0" | sed 's/^# \?//'
+            sed -n '2,40p' "$0" | sed 's/^# \?//'
             exit 0
             ;;
         *)
@@ -148,7 +149,7 @@ fi
 # Check pull secret exists
 if [ ! -f "$PULL_SECRET" ]; then
     echo "Error: Pull secret not found at $PULL_SECRET" >&2
-    echo "Provide path via --pull-secret or create ~/pull-secret.json" >&2
+    echo "Provide path via --pull-secret, the PULL_SECRET environment variable, or create ~/pull-secret.json" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Problem

Running `rhdp/wrapper.sh` for an Azure deployment resulted in a veritas
authentication failure during the "retrieving PCR measurements" step,
even though cluster provisioning (which also needs a pull secret)
succeeded.

`scripts/collect-firmware-refvals.sh` hardcodes its pull secret default
to `~/pull-secret.json` and only accepts an override via the
`-p/--pull-secret` CLI flag — it does not honor a `PULL_SECRET`
environment variable. `rhdp/wrapper.sh` and the `Makefile`'s
`collect-firmware-refvals` / `collect-azure-refvals` targets both invoke
the script without forwarding a pull secret override.

Meanwhile, `rhdp/rhdp-cluster-define.py` (used to provision the cluster
itself) *does* support `--pull-secret` / the `PULL_SECRET` env var, and
`rhdp/README.md` already documents `PULL_SECRET` as applying
automatically "to all three wrapper scripts without any extra flags" —
which was not actually true for reference-value collection.

Net effect: whenever the pull secret used to define the cluster (via
`PULL_SECRET`) lives somewhere other than `~/pull-secret.json`, veritas
silently authenticates with the wrong/stale credentials and fails.

## Fix

- `scripts/collect-firmware-refvals.sh`: default `PULL_SECRET` from the
  environment (`${PULL_SECRET:-${HOME}/pull-secret.json}`), matching the
  precedence already used by `rhdp-cluster-define.py`'s
  `resolve_pull_secret()`. `-p/--pull-secret` still takes precedence when
  passed explicitly.
- `rhdp/wrapper.sh`: explicitly forward `--pull-secret` to the refval
  collection step, alongside the script's other explicit credential
  checks (`GUID`, `CLIENT_ID`, etc.).
- Updated `README.md`, `docs/firmware-reference-values.md`, and the
  script's own `--help`/error text to document the `PULL_SECRET`
  override.

## Testing

This also fixes the plain Makefile path, which previously had no way to
pass a pull secret override at all:

```bash
export PULL_SECRET=/path/to/pull-secret.json
make collect-azure-refvals
# or
make collect-azure-refvals PULL_SECRET=/path/to/pull-secret.json
```

Verified locally:
- `bash -n` syntax check on both modified scripts
- `--help` output renders correctly after the header-comment line shift
- `${PULL_SECRET:-${HOME}/pull-secret.json}` precedence behaves as
  expected with and without the env var set, and `-p`/`--pull-secret`
  still overrides both

Verification pending on the APAC lab jump host / RHDP Azure environment
where the original failure was observed (full `rhdp/wrapper.sh` run and
`make collect-azure-refvals` with `PULL_SECRET` set to a non-default
path).