### PR TITLE
fix: export REGISTRY_AUTH_FILE so cosign can auth against registry.redhat.io

### DIFF
--- a/scripts/collect-firmware-refvals.sh
+++ b/scripts/collect-firmware-refvals.sh
@@ -153,6 +153,25 @@ if [ ! -f "$PULL_SECRET" ]; then
     exit 1
 fi
 
+if [ "$PLATFORM" = "azure" ]; then
+    # veritas passes --authfile to skopeo for pulling/inspecting the
+    # dm-verity image, but its cosign-based signature verification step
+    # invokes `cosign verify` directly with no auth args at all. cosign
+    # (via go-containerregistry's DefaultKeychain) only picks up
+    # credentials from ~/.docker/config.json, $DOCKER_CONFIG/config.json,
+    # or -- if neither of those exists -- $REGISTRY_AUTH_FILE. Export the
+    # latter so the pull secret authenticates the registry.redhat.io pull
+    # cosign does internally; otherwise it silently falls back to
+    # anonymous auth and fails with a confusing UNAUTHORIZED error.
+    export REGISTRY_AUTH_FILE="$PULL_SECRET"
+    if [ -f "${HOME}/.docker/config.json" ]; then
+        echo "WARNING: ${HOME}/.docker/config.json exists and takes precedence over" >&2
+        echo "  REGISTRY_AUTH_FILE for cosign's registry auth. If it lacks" >&2
+        echo "  registry.redhat.io credentials, cosign verification will still fail" >&2
+        echo "  with UNAUTHORIZED regardless of --pull-secret/PULL_SECRET." >&2
+    fi
+fi
+
 # Build version args and resolve version for display
 VERSION_ARG_NAME=""
 VERSION_ARG_VALUE=""


### PR DESCRIPTION
## Problem

`make collect-azure-refvals PULL_SECRET=<valid pull secret>` fails during veritas's cosign signature verification step:

```
ERROR: cosign verify --key /tmp/.../cosign-pub-key.pem --insecure-ignore-tlog registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:...
Error: GET https://registry.redhat.io/auth/realms/rhcc/.../auth?...: UNAUTHORIZED: Please login to the Red Hat Registry using your Customer Portal credentials.
```

This happens **even with a known-good pull secret**, including after #139 (which fixed `PULL_SECRET` env var precedence but doesn't touch this).

## Root cause

veritas (`ContainerImage.verify()` in `veritas/container.py`) passes `--authfile` to `skopeo` for pulling/inspecting the dm-verity image, but its cosign-based signature verification step shells out to `cosign verify <image_ref>` directly with **no auth args at all**. Confirmed in both the pinned `osc-veritas==0.1.3rc1` release and the upstream [confidential-devhub/veritas](https://github.com/confidential-devhub/veritas) `main` branch (`src/veritas/container.py`) — this is a veritas bug, not a coco-pattern or pull-secret problem.

cosign's default credential keychain (go-containerregistry's `authn.DefaultKeychain`) never sees the pull secret, so it silently falls back to anonymous registry auth.

## Fix

No veritas changes needed. cosign's `DefaultKeychain` checks, in order:
1. `~/.docker/config.json`
2. `$DOCKER_CONFIG/config.json`
3. `$REGISTRY_AUTH_FILE`
4. podman's `auth.json`
5. anonymous

OpenShift pull secrets are already docker-config-json format, so `scripts/collect-firmware-refvals.sh` now exports `REGISTRY_AUTH_FILE=$PULL_SECRET` before invoking `veritas` for the Azure branch (the only branch that shells out to cosign). `veritas`'s subprocess wrapper inherits the parent env, so cosign picks up the credentials with zero reformatting.

Also emits a warning if `~/.docker/config.json` exists, since per the same keychain lookup order it takes precedence over `REGISTRY_AUTH_FILE` and could mask this fix if it lacks `registry.redhat.io` creds.

## Testing

Verified the root cause by downloading and reading the pinned `osc-veritas==0.1.3rc1` wheel's source directly, and cross-checked against upstream `confidential-devhub/veritas` `main`, plus `go-containerregistry`'s `authn/keychain.go` to confirm the credential lookup order. Not able to exercise `make collect-azure-refvals` end-to-end in this environment (no cosign/veritas/live cluster) — requesting a real-world run on the jump host to confirm before merge.
