### PR TITLE
fix: use registry.access.redhat.com for Azure workload images

### DIFF
--- a/values-azure.yaml
+++ b/values-azure.yaml
@@ -119,6 +119,14 @@ clusterGroup:
       syncPolicy:
         automated:
           prune: true
+      overrides:
+        # Use the unauthenticated registry.access.redhat.com mirror instead of
+        # registry.redhat.io on Azure -- peer-pods (kata-remote) CVMs pull
+        # images via guest-pull and registry.redhat.io requires credentials
+        # that are non-trivial to thread through that path. Same digest,
+        # same content, just served from a registry that doesn't require auth.
+        - name: image
+          value: "registry.access.redhat.com/ubi9/httpd-24@sha256:68a91ff691092f455fea682330c499588747231c16516cd4f35aff821e6847f2"
 
     kbs-access-curl:
       name: kbs-access-curl
@@ -128,6 +136,10 @@ clusterGroup:
       syncPolicy:
         automated:
           prune: true
+      overrides:
+        # See hello-openshift override above for rationale.
+        - name: image
+          value: "registry.access.redhat.com/ubi9/httpd-24@sha256:68a91ff691092f455fea682330c499588747231c16516cd4f35aff821e6847f2"
 
     kbs-access-sealed:
       name: kbs-access-sealed
@@ -137,6 +149,10 @@ clusterGroup:
       syncPolicy:
         automated:
           prune: true
+      overrides:
+        # See hello-openshift override above for rationale.
+        - name: image
+          value: "registry.access.redhat.com/ubi9/httpd-24@sha256:68a91ff691092f455fea682330c499588747231c16516cd4f35aff821e6847f2"
 
     kyverno:
       name: kyverno


### PR DESCRIPTION
## Problem

The three Azure workload charts (`hello-openshift`, `kbs-access-curl`, `kbs-access-sealed`) all default to `registry.redhat.io/ubi9/httpd-24@sha256:...`, which requires registry authentication. On Azure, these run as peer-pods (`kata-remote`) where the image is pulled via guest-pull *inside* the confidential VM rather than by the host container runtime — getting a working pull secret threaded through that path has been an ongoing source of image-pull failures.

## Fix

Override `image` for these three Applications in `values-azure.yaml` to the **same digest** served from `registry.access.redhat.com` instead, which doesn't require authentication:

```
registry.access.redhat.com/ubi9/httpd-24@sha256:68a91ff691092f455fea682330c499588747231c16516cd4f35aff821e6847f2
```

Verified this resolves to the identical manifest (same `Docker-Content-Digest`) as the `registry.redhat.io` reference, unauthenticated:

```
$ curl -sI "https://registry.access.redhat.com/v2/ubi9/httpd-24/manifests/sha256:68a91ff691092f455fea682330c499588747231c16516cd4f35aff821e6847f2"
HTTP/1.1 200 OK
Docker-Content-Digest: sha256:68a91ff691092f455fea682330c499588747231c16516cd4f35aff821e6847f2
```

This mirrors existing precedent in the repo: `kbs-access-curl`'s `initImage` already uses `registry.access.redhat.com/ubi9/ubi:latest` for the same reason (`charts/coco-supported/kbs-access-curl/values.yaml:5`).

## Scope

Connected Azure (`values-azure.yaml`) only, per request. Baremetal (`values-baremetal.yaml`) and Azure spoke/mirror topologies are unchanged.
