### PR TITLE
chore: bump sandboxed-containers-operator to v1.13.1

### DIFF
--- a/airgap/imageset-config-4.22.yaml
+++ b/airgap/imageset-config-4.22.yaml
@@ -31,8 +31,8 @@ mirror:
         - name: sandboxed-containers-operator
           channels:
             - name: stable
-              minVersion: "1.13.0"
-              maxVersion: "1.13.0"
+              minVersion: "1.13.1"
+              maxVersion: "1.13.1"
         - name: trustee-operator
           channels:
             - name: stable

--- a/values-azure-spoke.yaml
+++ b/values-azure-spoke.yaml
@@ -26,7 +26,7 @@ clusterGroup:
       namespace: openshift-sandboxed-containers-operator
       channel: stable
       installPlanApproval: Manual
-      csv: sandboxed-containers-operator.v1.12.0
+      csv: sandboxed-containers-operator.v1.13.1
     cert-manager:
       name: openshift-cert-manager-operator
       namespace: cert-manager-operator

--- a/values-azure.yaml
+++ b/values-azure.yaml
@@ -36,7 +36,7 @@ clusterGroup:
       namespace: openshift-sandboxed-containers-operator
       channel: stable
       installPlanApproval: Manual
-      csv: sandboxed-containers-operator.v1.13.0
+      csv: sandboxed-containers-operator.v1.13.1
     trustee:
       name: trustee-operator
       namespace: trustee-operator-system

--- a/values-baremetal-hub.yaml
+++ b/values-baremetal-hub.yaml
@@ -48,7 +48,7 @@ clusterGroup:
       namespace: openshift-sandboxed-containers-operator
       channel: stable
       installPlanApproval: Manual
-      csv: sandboxed-containers-operator.v1.13.0
+      csv: sandboxed-containers-operator.v1.13.1
       annotations:
         argocd.argoproj.io/sync-wave: "10"
     trustee:

--- a/values-baremetal-spoke.yaml
+++ b/values-baremetal-spoke.yaml
@@ -33,7 +33,7 @@ clusterGroup:
       namespace: openshift-sandboxed-containers-operator
       channel: stable
       installPlanApproval: Manual
-      csv: sandboxed-containers-operator.v1.13.0
+      csv: sandboxed-containers-operator.v1.13.1
       annotations:
         argocd.argoproj.io/sync-wave: "10"
     cert-manager:

--- a/values-baremetal.yaml
+++ b/values-baremetal.yaml
@@ -47,7 +47,7 @@ clusterGroup:
       namespace: openshift-sandboxed-containers-operator
       channel: stable
       installPlanApproval: Manual
-      csv: sandboxed-containers-operator.v1.13.0
+      csv: sandboxed-containers-operator.v1.13.1
       annotations:
         argocd.argoproj.io/sync-wave: "10"
     trustee:


### PR DESCRIPTION
## What

Bumps the pinned `sandboxed-containers-operator` CSV from `v1.13.0` to `v1.13.1`:

| File | Before | After |
|---|---|---|
| `values-azure.yaml` | `v1.13.0` | `v1.13.1` |
| `values-azure-spoke.yaml` | `v1.12.0` | `v1.13.1` |
| `values-baremetal.yaml` | `v1.13.0` | `v1.13.1` |
| `values-baremetal-hub.yaml` | `v1.13.0` | `v1.13.1` |
| `values-baremetal-spoke.yaml` | `v1.13.0` | `v1.13.1` |
| `airgap/imageset-config-4.22.yaml` (oc-mirror bundle pin) | `1.13.0` | `1.13.1` |

`values-azure-spoke.yaml` was independently pinned to `v1.12.0` — the only
outlier vs. every other topology's `v1.13.0`. Per team decision, spoke should
always track primary (`values-azure.yaml`), so this reconciles the drift
directly to `v1.13.1` rather than bumping it in place at `v1.12.0`.

## Depends on

#142 — without that fix, `make collect-azure-refvals` would resolve OSC
version via live-cluster auto-detect / `"latest"` fallback rather than this
pin, and could silently collect the wrong reference values again (the exact
bug #142 fixes).

## Verification

- `osc-dm-verity-image:1.13.1` confirmed to exist and verify successfully via
  cosign against `registry.redhat.io` (used throughout #142's testing).
- **Not independently confirmed:** whether the `sandboxed-containers-operator`
  1.13.1 bundle is present in the `redhat-operator-index:v4.22` catalog's
  `stable` channel (relevant to the `imageset-config-4.22.yaml` change).
  `skopeo inspect` on the full catalog index enumerates several thousand tags
  and wasn't practical to use for channel introspection; `oc-mirror list
  operators` hit a registry auth error unrelated to pull-secret validity.
  **Please verify catalog channel availability before running an airgap
  mirror against this pin.**

## Operational follow-up (not done in this PR)

On any existing deployment, after this merges:

```bash
make collect-azure-refvals      # or collect-firmware-refvals for bare metal
make load-secrets
```

Reference-value hashes tied to `1.13.0` (e.g. `snp_pcr09`/`snp_pcr12`, the
initrd/cmdline PCR measurements) do not match a `1.13.1` install.
