### PR TITLE
revert: registry.access.redhat.com override + use debug-initdata for kbs-access-sealed

### DIFF
--- a/charts/coco-supported/kbs-access-sealed/templates/deployment.yaml
+++ b/charts/coco-supported/kbs-access-sealed/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       labels:
         app: kbs-access-sealed
       annotations:
-        coco.io/initdata-configmap: initdata
+        coco.io/initdata-configmap: debug-initdata
     spec:
       runtimeClassName: {{ .Values.global.coco.runtimeClassName }}
       containers:
@@ -48,5 +48,5 @@ spec:
           secretName: kbs-sealed-secret
       - name: initdata
         configMap:
-          name: initdata
+          name: debug-initdata
           optional: false

--- a/values-azure.yaml
+++ b/values-azure.yaml
@@ -119,14 +119,6 @@ clusterGroup:
       syncPolicy:
         automated:
           prune: true
-      overrides:
-        # Use the unauthenticated registry.access.redhat.com mirror instead of
-        # registry.redhat.io on Azure -- peer-pods (kata-remote) CVMs pull
-        # images via guest-pull and registry.redhat.io requires credentials
-        # that are non-trivial to thread through that path. Same digest,
-        # same content, just served from a registry that doesn't require auth.
-        - name: image
-          value: "registry.access.redhat.com/ubi9/httpd-24@sha256:68a91ff691092f455fea682330c499588747231c16516cd4f35aff821e6847f2"
 
     kbs-access-curl:
       name: kbs-access-curl
@@ -136,10 +128,6 @@ clusterGroup:
       syncPolicy:
         automated:
           prune: true
-      overrides:
-        # See hello-openshift override above for rationale.
-        - name: image
-          value: "registry.access.redhat.com/ubi9/httpd-24@sha256:68a91ff691092f455fea682330c499588747231c16516cd4f35aff821e6847f2"
 
     kbs-access-sealed:
       name: kbs-access-sealed
@@ -149,10 +137,6 @@ clusterGroup:
       syncPolicy:
         automated:
           prune: true
-      overrides:
-        # See hello-openshift override above for rationale.
-        - name: image
-          value: "registry.access.redhat.com/ubi9/httpd-24@sha256:68a91ff691092f455fea682330c499588747231c16516cd4f35aff821e6847f2"
 
     kyverno:
       name: kyverno


### PR DESCRIPTION
## What

**1. Reverts #141** (`8c2aa7e`), which added `overrides` blocks to
`values-azure.yaml` pointing `hello-openshift`, `kbs-access-curl`, and
`kbs-access-sealed` at `registry.access.redhat.com/ubi9/httpd-24@sha256:68a91ff6...`
instead of the chart default (`registry.redhat.io/ubi9/httpd-24`, same
digest/content).

This is a clean `git revert` of 8c2aa7e — no conflicts, removes exactly the
16 lines that PR added and nothing else. `values-azure.yaml`'s workload
images go back to the chart's default `registry.redhat.io` reference on
connected Azure.

Scope: connected Azure (`values-azure.yaml`) only, matching the scope of the
original change — baremetal and the Azure spoke/mirror topologies were never
touched by #141 and are unaffected by this revert.

**2. `kbs-access-sealed` now uses `debug-initdata`**, matching
`kbs-access-curl` (which already mounts `debug-initdata` via both the
`coco.io/initdata-configmap` annotation and the `initdata` volume). Both
`initdata` and `debug-initdata` ConfigMaps are generated by the same
`ansible/init-data-gzipper.yaml` playbook, and the RVPS `init_data`
reference value already includes both variants' hashes (see
`rvps-values-policies.yaml`'s `init_data` entry: `pcr8Hash`, `debugPcr8Hash`,
`rawHash`, `debugRawHash`), so this doesn't affect attestation — it just
makes the two kbs-access test workloads consistent with each other.
