### PR TITLE
fix: run 'make cache-keys' in RHDP wrapper scripts

### DIFF
--- a/rhdp/wrapper-multicluster.sh
+++ b/rhdp/wrapper-multicluster.sh
@@ -170,6 +170,11 @@ echo "setting up secrets"
 bash ./scripts/gen-secrets.sh
 
 echo "---------------------"
+echo "caching Red Hat signing keys"
+echo "---------------------"
+make cache-keys
+
+echo "---------------------"
 echo "retrieving PCR measurements"
 echo "---------------------"
 $PYTHON_CMD ./scripts/collect_firmware_refvals.py --platform azure

--- a/rhdp/wrapper.sh
+++ b/rhdp/wrapper.sh
@@ -187,6 +187,11 @@ echo "setting up secrets"
 bash ./scripts/gen-secrets.sh
 
 echo "---------------------"
+echo "caching Red Hat signing keys"
+echo "---------------------"
+make cache-keys
+
+echo "---------------------"
 echo "retrieving PCR measurements"
 echo "---------------------"
 $PYTHON_CMD ./scripts/collect_firmware_refvals.py --platform azure --tee snp --pull-secret "${PULL_SECRET:-$HOME/pull-secret.json}"


### PR DESCRIPTION
## Problem

On a bare/fresh Azure install via `rhdp/wrapper.sh`, `~/.coco-pattern/SIGSTORE-redhat-release3` was never generated.

`values-secret.yaml.template`'s `sigstore-keys` secret unconditionally
references that path:

```yaml
- name: sigstore-keys
  vaultPrefixes:
  - hub
  fields:
  - name: redhat-release3
    path: ~/.coco-pattern/SIGSTORE-redhat-release3
```

It's fetched by the `make cache-keys` Makefile target — but neither
`rhdp/wrapper.sh` nor `rhdp/wrapper-multicluster.sh` ever called that
target. They only ran `gen-secrets.sh` (KBS/JWK keys + refval placeholders)
and `collect_firmware_refvals.py` (PCR measurements) before invoking
`./pattern.sh make install`, which is what actually loads
`values-secret-coco-pattern.yaml` into Vault.

## Fix

Add `make cache-keys` to both wrapper scripts, right after `gen-secrets.sh`
and before the PCR measurement collection step.

`rhdp/wrapper-cluster-only.sh` is unaffected — it only provisions the
cluster (`openshift-install`) and never runs `gen-secrets.sh` or
`pattern.sh make install`.

## Verification

Audited every active (uncommented) `path:` reference in
`values-secret.yaml.template` against what the wrapper scripts generate for
a connected Azure deployment:

| Secret field | Path | Generated by |
|---|---|---|
| `sealedSecretsSigningKey.public` | `sealed-secrets-signing-pub.jwk` | `gen-secrets.sh` (jose) |
| `sigstore-keys.redhat-release3` | `SIGSTORE-redhat-release3` | `make cache-keys` **(this PR)** |
| `pcrStash.json` | `measurements.json` | `collect_firmware_refvals.py --platform azure` |
| `firmwareReferenceValues.json` | `firmware-reference-values.json` | sibling placeholder (auto-created) |

All four are now covered by the wrapper scripts' generation steps.
